### PR TITLE
Fix: Remove padding

### DIFF
--- a/mtz-update-password.html
+++ b/mtz-update-password.html
@@ -38,9 +38,6 @@ Custom property | Description | Default
       .password-input {
         @apply --mtz-update-password-input-fields;
       }
-      mtz-validation-status {
-        padding-top: 10px;
-      }
     </style>
 
     <slot name="title"></slot>


### PR DESCRIPTION
This padding is impossible to override and looks fine without it. Removing allows configurability through the `--mtz-validation-status` mixin.