### PR TITLE
Fix: numbers count as symbols, error padding

### DIFF
--- a/mtz-update-password.html
+++ b/mtz-update-password.html
@@ -33,6 +33,8 @@ Custom property | Description | Default
         @apply --mtz-update-password-input;
       }
       #retype-password {
+        padding-bottom: 6px;
+
         @apply --mtz-update-password-retype-input;
       }
       .password-input {
@@ -125,7 +127,7 @@ Custom property | Description | Default
         /* Allowed symbols regex pattern, gets combined with characters to build allowedPattern */
         allowedSymbols: {
           type: String,
-          value: '~`!@#\\$%\\^&\\*\\(\\)_\\+-=\\[\\]{}\\|;:\'\",<\\.>\\/\\?;',
+          value: '~`!@#\\$%\\^&\\*\\(\\)_\\+\\-=\\[\\]{}\\|;:\'\",<\\.>\\/\\?;',
         },
         /* AlwaysFloatLabel override for the password input */
         alwaysFloatLabel: {
@@ -379,10 +381,10 @@ Custom property | Description | Default
        *
        * @protected
        * @param {String} value
-       * @param {String} symbols
+       * @param {String} [symbols = '']
        * @return {String}
        */
-      __getPattern(value, symbols) {
+      __getPattern(value, symbols = '') {
         // Take our value and check to see what symbols require a '\' prefix, then inject it as needed.
         return (value || '').replace(
           new RegExp(`([${symbols}])`, 'g'),


### PR DESCRIPTION
Also added a default value of an empty string to __getPattern for symbols so you can use an undefined value for allowedSymbols and it will use the default regex associated with the validator instead.